### PR TITLE
Hardcode graphviz dep range

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
     - python-xxhash
     - pytest-runner
     - pytest
+    - nb_conda_kernels
 
   run:
     - aiofiles
@@ -59,6 +60,7 @@ requirements:
     - python-xxhash
     - pytest-runner
     - pytest
+    - nb_conda_kernels
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: "065f9d4b3e821cedf1e9dce5003f8cec56331306a4590f57985ba1f0326b1ee5"
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vvv --no-deps"
   noarch: python 
 
@@ -21,7 +21,7 @@ requirements:
     - aioserial
     - altair
     - bokeh
-    - graphviz
+    - graphviz >=2.38.0
     - ipython >=7.0
     - ipywidgets
     - jupyter
@@ -43,7 +43,7 @@ requirements:
     - aioserial
     - altair
     - bokeh
-    - graphviz
+    - graphviz >=2.38.0
     - ipython >=7.0
     - ipywidgets
     - jupyter


### PR DESCRIPTION
Was unable to install on Windows. When installing the bz2 from Conda, I see that `graphviz >=2.40.1,<3.0a0` got appended to the run requirements. Since there's no Windows 2.40.1 available, I'm explicitly allowing 2.38.0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
